### PR TITLE
Add convert function.

### DIFF
--- a/lib/setlist.js
+++ b/lib/setlist.js
@@ -100,6 +100,25 @@ Setlist.async = function async(fn) {
     return exec;
 }
 
+Setlist.convert = function convert(src) {
+    // Try to iterate ownPropertyNames and find generator function
+    // Then convert them into promise return function
+    let properties = Object.getOwnPropertyNames(src);
+    let extended = Object.create(src);
+    // Traverse
+    for (let property of properties) {
+        if ('constructor' in src[property] &&
+            src[property].constructor.name === 'GeneratorFunction') {
+            // Create own wrapping method
+            extended[property] = function proxy() {
+                return Setlist(src[property].apply(src, arguments));
+            }
+        }
+    }
+    // Return new object
+    return extended;
+}
+
 Setlist.worker = function worker(done, halt, fn, value) {
     try {
         // Try to run generator function

--- a/test/setlist.js
+++ b/test/setlist.js
@@ -23,6 +23,9 @@ describe('Method probes', function() {
     it('$.async() should be a function and take 1 argument', function() {
         $.async.should.be.a.Function().with.lengthOf(1);
     });
+    it('$.convert() should be a function and take 1 argument', function() {
+        $.convert.should.be.a.Function().with.lengthOf(1);
+    });
     it('$.worker() should be a function and take 4 arguments', function() {
         $.worker.should.be.a.Function().with.lengthOf(4);
     });
@@ -128,5 +131,29 @@ describe('Setlist $ test', function() {
     });
     it('Should correctly return value after .next()', function() {
         return $(s.gf()).next(s.gf(true)).should.fulfilledWith(true);
+    });
+});
+describe('Setlist $.convert() test', function() {
+    let target = undefined;
+
+    before(function() {
+        // Start convertion process
+        target = $.convert(s.objSrc);
+    });
+
+    it('Target should only have 1 own property', function() {
+        Object.getOwnPropertyNames(target).should.have.lengthOf(1);
+    });
+    it('Target should have same version of fn()', function() {
+        target.fn.should.equal(s.objSrc.fn);
+    });
+    it('Target gf() should be a function', function() {
+        target.gf.should.be.a.Function();
+    });
+    it('Target gf() should return a promise', function() {
+        $.identify(target.gf()).should.equal('Promise');
+    });
+    it('Target gf() should eventually return value', function() {
+        return target.gf(true).should.eventually.equal(true);
     });
 });

--- a/test/snippets/index.js
+++ b/test/snippets/index.js
@@ -31,7 +31,7 @@ s.async = function(cb, x) {
     if (x !== undefined) {
         setTimeout(x, cb);
     } else {
-        setTimeout(cb);
+        process.nextTick(cb);
     }
 }
 
@@ -117,4 +117,9 @@ s.gfErrPromise = function*() {
 
 s.gfLong = function*() {
     return yield s.async.bind(s, 1000);
+}
+
+s.objSrc = {
+    gf: function*(v) { return yield s.promise(v) },
+    fn: function(v) { return v }
 }


### PR DESCRIPTION
Convert function will dynamically extends the source object and search for own property with generator function type. Then, it will wrap the generator function with new function that returns promise so it is now able to execute the function directly without calling List()