### PR TITLE
Disable auto-resolve on return keyword

### DIFF
--- a/lib/setlist.js
+++ b/lib/setlist.js
@@ -53,23 +53,13 @@ function run(fn) {
 
     // Generator next function
     function next(r) {
-      let cont
-      let fail
       if (r.done) {
-        cont = resolve
-        fail = reject
+        resolve(r.value)
       } else {
-        cont = exec
-        fail = error
-      }
-
-      if (isPromise(r.value)) {
-        r.value.then(cont).catch (fail)
-      } else if (isGenerator(r.value)) {
-        run(r.value).then(cont).catch (fail)
-      } else {
-        if (r.done) {
-          resolve(r.value)
+        if (isPromise(r.value)) {
+          r.value.then(exec).catch(error)
+        } else if (isGenerator(r.value)) {
+          run(r.value).then(exec).catch(error)
         } else {
           process.nextTick(() => exec(r.value))
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setlist",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Sequential-ish your asynchronous code with ES6 Generator Function and Promise",
   "main": "index.js",
   "scripts": {

--- a/test/setlist.js
+++ b/test/setlist.js
@@ -65,26 +65,14 @@ describe('Generator runner sanity checking test', function () {
 
 describe('Generator runner functional test', function () {
   it('Non-async return', function () {
-    let gf = function* (v) { return v }
-    return $(gf(true)).should.fulfilledWith(true)
-  })
-  it('Non-async yield return', function () {
     let gf = function* (v) { return yield v }
     return $(gf(true)).should.fulfilledWith(true)
   })
   it('Promise return', function () {
-    let gf = function* (v) { return Promise.resolve(v) }
-    return $(gf(true)).should.fulfilledWith(true)
-  })
-  it('Promise yield return', function () {
     let gf = function* (v) { return yield Promise.resolve(v) }
     return $(gf(true)).should.fulfilledWith(true)
   })
   it('Generator function return', function () {
-    let gf = function* (v) { return function* (v) { return v }(v) }
-    return $(gf(true)).should.fulfilledWith(true)
-  })
-  it('Generator function yield return', function () {
     let gf = function* (v) { return yield function* (v) { return v }(v) }
     return $(gf(true)).should.fulfilledWith(true)
   })


### PR DESCRIPTION
Disabling auto-resolve functionality to auto resolve variable that passed in return keyword. This behavior could impact negatively on intentional non-resolving promise or generator return (e.g. returning Promises that needs to be resolved later on)